### PR TITLE
Add LAMBDA to create_detector & update_org_config

### DIFF
--- a/src/org_setup/resources/guardduty.py
+++ b/src/org_setup/resources/guardduty.py
@@ -146,6 +146,7 @@ class GuardDuty:
                             },
                         ],
                     },
+                    {"Name": "LAMBDA_NETWORK_LOGS", "Status": "ENABLED"},
                 ],
             )
             detector_ids.append(response["DetectorId"])
@@ -180,6 +181,7 @@ class GuardDuty:
                             },
                         ],
                     },
+                    {"Name": "LAMBDA_NETWORK_LOGS", "Status": "NEW"},
                 ],
                 AutoEnableOrganizationMembers="ALL",
             )


### PR DESCRIPTION
_Issue #, if available:_
N/A

_Description of changes:_
Add Feature "LAMBDA_NETWORK_LOGS" to [create_detector](https://github.com/aws-samples/aws-control-tower-org-setup-sample/blob/c8fa668fb6bc88e344b57dd8c843c718930ce54f/src/org_setup/resources/guardduty.py#L68) method, specifically the [create_detector](https://github.com/aws-samples/aws-control-tower-org-setup-sample/blob/c8fa668fb6bc88e344b57dd8c843c718930ce54f/src/org_setup/resources/guardduty.py#L119) and [update_organization_configuration](https://github.com/aws-samples/aws-control-tower-org-setup-sample/blob/c8fa668fb6bc88e344b57dd8c843c718930ce54f/src/org_setup/resources/guardduty.py#LL154C25-L154C58) API calls as it is [already on the update_detector](https://github.com/aws-samples/aws-control-tower-org-setup-sample/blob/c8fa668fb6bc88e344b57dd8c843c718930ce54f/src/org_setup/resources/guardduty.py#L115) call.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
